### PR TITLE
Fix smart pointer docs

### DIFF
--- a/pulsar-utils/src/pool.rs
+++ b/pulsar-utils/src/pool.rs
@@ -22,9 +22,10 @@ const ARENA_SIZE_BYTES: usize = 64 * 1024 * 1024;
 
 /// Pointer to a value allocated in a [`Pool`]. The semantics are:
 ///
-/// - [`PartialEq`], [`Eq`], [`Display`], [`Debug`] from the `T` value itself.
-/// - [`Clone`], [`Copy`], [`Hash`], [`Deref`], [`DerefMut`], [`AsRef`],
-///   [`AsMut`] from the pointer.
+/// - [`PartialEq`], [`Eq`], [`Hash`], [`Display`], [`Debug`] from the `T` value
+///   itself.
+/// - [`Clone`], [`Copy`], [`Deref`], [`DerefMut`], [`AsRef`], [`AsMut`] from
+///   the pointer.
 pub struct Handle<T> {
     pointer: *mut T
 }


### PR DESCRIPTION
Reflects that `Hash` is now derived from the underlying type. (Might consider hash consing at some point so can use pointer)